### PR TITLE
💬Refactor: Update request payload to enforce JSON format with response_format

### DIFF
--- a/src/main/java/com/angrybug/remedi2/Challenge/Service/ChallengeService.java
+++ b/src/main/java/com/angrybug/remedi2/Challenge/Service/ChallengeService.java
@@ -73,15 +73,21 @@ public class ChallengeService {
                 "The pharmacist's answer should be concise, no longer than 2 sentences, addressing the question directly and professionally, and aligned with the provided context and prescription details.\n\n" +
                 "Here is the JSON data for this session:\n" + requestBodyStr;
 
-        // message 생성
-        ObjectNode message = objectMapper.createObjectNode();
-        message.put("role", "user");
-        message.put("content", prompt); // 프롬프트 추가
+        // ObjectMapper 사용
+        ObjectNode systemMessage = objectMapper.createObjectNode();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", "Please ensure that the output is always a valid JSON object. The response must be in strict JSON format.");
+
+        // 사용자 메시지 생성
+        ObjectNode userMessage = objectMapper.createObjectNode();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt); // 프롬프트 추가
 
         // 전체 요청 생성
         ObjectNode requestBody = objectMapper.createObjectNode();
-        requestBody.put("model", "gpt-4");
-        requestBody.set("messages", objectMapper.createArrayNode().add(message));
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.set("messages", objectMapper.createArrayNode().add(systemMessage).add(userMessage));
+        requestBody.putObject("response_format").put("type", "json_object");
 
         try {
             // WebClient 요청
@@ -182,15 +188,21 @@ public class ChallengeService {
                 + "Here is the input data:\n"
                 + requestBodyStr;
 
-        // message 생성
-        ObjectNode message = objectMapper.createObjectNode();
-        message.put("role", "user");
-        message.put("content", prompt); // 프롬프트 추가
+        // ObjectMapper 사용
+        ObjectNode systemMessage = objectMapper.createObjectNode();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", "Please ensure that the output is always a valid JSON object. The response must be in strict JSON format.");
+
+        // 사용자 메시지 생성
+        ObjectNode userMessage = objectMapper.createObjectNode();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt); // 프롬프트 추가
 
         // 전체 요청 생성
         ObjectNode requestBody = objectMapper.createObjectNode();
-        requestBody.put("model", "gpt-4");
-        requestBody.set("messages", objectMapper.createArrayNode().add(message));
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.set("messages", objectMapper.createArrayNode().add(systemMessage).add(userMessage));
+        requestBody.putObject("response_format").put("type", "json_object");
 
         try {
             // WebClient 요청
@@ -280,15 +292,21 @@ public class ChallengeService {
                 + "The provided data is as follows:\n"
                 + requestBodyStr;
 
-        // message 생성
-        ObjectNode message = objectMapper.createObjectNode();
-        message.put("role", "user");
-        message.put("content", prompt); // 프롬프트 추가
+        // ObjectMapper 사용
+        ObjectNode systemMessage = objectMapper.createObjectNode();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", "Please ensure that the output is always a valid JSON object. The response must be in strict JSON format.");
+
+        // 사용자 메시지 생성
+        ObjectNode userMessage = objectMapper.createObjectNode();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt); // 프롬프트 추가
 
         // 전체 요청 생성
         ObjectNode requestBody = objectMapper.createObjectNode();
-        requestBody.put("model", "gpt-4");
-        requestBody.set("messages", objectMapper.createArrayNode().add(message));
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.set("messages", objectMapper.createArrayNode().add(systemMessage).add(userMessage));
+        requestBody.putObject("response_format").put("type", "json_object");
 
         try {
             // WebClient 요청

--- a/src/main/java/com/angrybug/remedi2/Practice/Service/PracticeService.java
+++ b/src/main/java/com/angrybug/remedi2/Practice/Service/PracticeService.java
@@ -73,15 +73,21 @@ public class PracticeService {
         // JSON 데이터 추가
         prompt += " Here is the JSON data for this session:\n" + requestBodyStr;
 
-        // message 생성
-        ObjectNode message = objectMapper.createObjectNode();
-        message.put("role", "user");
-        message.put("content", prompt); // 프롬프트 추가
+        // ObjectMapper 사용
+        ObjectNode systemMessage = objectMapper.createObjectNode();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", "Please ensure that the output is always a valid JSON object. The response must be in strict JSON format.");
+
+        // 사용자 메시지 생성
+        ObjectNode userMessage = objectMapper.createObjectNode();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt); // 프롬프트 추가
 
         // 전체 요청 생성
         ObjectNode requestBody = objectMapper.createObjectNode();
-        requestBody.put("model", "gpt-4");
-        requestBody.set("messages", objectMapper.createArrayNode().add(message));
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.set("messages", objectMapper.createArrayNode().add(systemMessage).add(userMessage));
+        requestBody.putObject("response_format").put("type", "json_object");
 
         try {
             // WebClient 요청
@@ -151,15 +157,21 @@ public class PracticeService {
         prompt += " Here is the JSON data for this session:\n" + requestBodyStr;
 
 
-        // message 생성
-        ObjectNode message = objectMapper.createObjectNode();
-        message.put("role", "user");
-        message.put("content", prompt); // 프롬프트 추가
+        // ObjectMapper 사용
+        ObjectNode systemMessage = objectMapper.createObjectNode();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", "Please ensure that the output is always a valid JSON object. The response must be in strict JSON format.");
+
+        // 사용자 메시지 생성
+        ObjectNode userMessage = objectMapper.createObjectNode();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt); // 프롬프트 추가
 
         // 전체 요청 생성
         ObjectNode requestBody = objectMapper.createObjectNode();
-        requestBody.put("model", "gpt-4");
-        requestBody.set("messages", objectMapper.createArrayNode().add(message));
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.set("messages", objectMapper.createArrayNode().add(systemMessage).add(userMessage));
+        requestBody.putObject("response_format").put("type", "json_object");
 
         try {
             // WebClient 요청


### PR DESCRIPTION
- Added system message in English to ensure output is always a valid JSON object.
- Set `response_format` to `{ "type": "json_object" }` in the request body.
- Changed model to `gpt-4o-mini`.
- Included debugging output for request body validation.
